### PR TITLE
Update: apiService.js excluding login 401

### DIFF
--- a/client/src/services/apiService.js
+++ b/client/src/services/apiService.js
@@ -23,8 +23,10 @@ api.interceptors.response.use(
   },
   async (error) => {
     const originalRequest = error.config;
-    console.log(error.response);
-    if (error.response.status === 401 && !originalRequest._retry) {
+    const isUnauthorized = error.response.status === 401;
+    const isNotInvalidLoginCredentials = error.response.data.error !== "Invalid Login Credentials";
+    const hasNotBeenRetried = !originalRequest._retry;
+    if (isUnauthorized && isNotInvalidLoginCredentials && hasNotBeenRetried) {
       originalRequest._retry = true;
 
       try {
@@ -38,7 +40,6 @@ api.interceptors.response.use(
             },
           }
         );
-        console.log(response);
         const {accessToken} = response.data;
         tokenService.setAccessToken(accessToken);
         originalRequest.headers.Authorization = `Bearer ${accessToken}`;

--- a/server/api/auth/routes.py
+++ b/server/api/auth/routes.py
@@ -26,7 +26,7 @@ def login():
 
         if response["success"]:
             return jsonify(response), 200
-        elif response["error"] == "Invalid Credentials":
+        elif response["error"] == "Invalid Login Credentials":
             return jsonify(response), 401
         elif response["error"] == "Action Not Allowed":
             return jsonify(response), 403

--- a/server/api/auth/services.py
+++ b/server/api/auth/services.py
@@ -24,9 +24,9 @@ def login(email, password):
     try:
         # Check if email and password are valid
         if not validate_login_credentials(email, password):
-            logger.warning("Login Attempt Failed: by %s | Invalid Credentials", email)
-            create_audit_log("Login", email=email, details="Invalid Credentials")
-            return {"success": False, "error": "Invalid Credentials", "description": "Email Or Password Incorrect"}
+            logger.warning("Login Attempt Failed: by %s | Invalid Login Credentials", email)
+            create_audit_log("Login", email=email, details="Invalid Login Credentials")
+            return {"success": False, "error": "Invalid Login Credentials", "description": "Email Or Password Incorrect"}
 
         try:
             user = db.session.query(User).filter(User.email == email).first()


### PR DESCRIPTION
This pull request fixes the extra alert when, during login, invalid credentials are used. I believe it is a brute force solution but I can't see it impacting anything.

### Improvements to Error Handling and Logging:

* [`server/api/auth/services.py`](diffhunk://#diff-e8f87d37a59250858ac22ede51fa1fcfacc5f2541e6fe8959ac59a476465792dL27-R29): Made the error message more specific for invalid login attempts by replacing "Invalid Credentials" with "Invalid Login Credentials" in log messages, audit logs, and error responses. This will help with conflicts in [`client/src/services/apiService.js`].
* [`server/api/auth/routes.py`](diffhunk://#diff-1f03b1429fb649e84a1a5eac3e9f027a66f1e2ed53a4a8a5eca5a66592a909a5L29-R29): Updated the error condition in the login route to match the new error message.

### Enhancements to Retry Logic:

* [`client/src/services/apiService.js`](diffhunk://#diff-9afd22c27462197ed51e392118220b3e3eeda8d6c4ffbf4bf5374c308aa90b33L26-R29): Refined the retry logic in the API response interceptor by introducing clearer variable names (`isUnauthorized`, `isNotInvalidLoginCredentials`, `hasNotBeenRetried`) and ensuring retries only occur for unauthorized errors that are not related to invalid login credentials.

### Cleanup:

* [`client/src/services/apiService.js`](diffhunk://#diff-9afd22c27462197ed51e392118220b3e3eeda8d6c4ffbf4bf5374c308aa90b33L41): Removed unnecessary `console.log` statements for cleaner and more production-ready code.