### PR TITLE
Add: check if still in targeted route before checking

### DIFF
--- a/client/src/routes/AdminRoute.jsx
+++ b/client/src/routes/AdminRoute.jsx
@@ -15,28 +15,30 @@ const AdminRoute = () => {
   const { goToDashboard } = useRoleBasedNavigation();
   const navigate = useNavigate();
 
-  useEffect(() => {
-    if (!isAuthenticating && !isAuthenticated) {
-      showAlert("You Must Be Logged In To Access This Page", "warning");
-      navigate("/login");
-    }
+    useEffect(() => {
+    if (location.pathname === "/admin") {
 
-    if (!isAuthenticating && isAuthenticated && user.status === "not_onboarded") {
-      showAlert("Please Complete Your Onboarding", "warning");
-      navigate("/onboarding");
-    }
+      if (!isAuthenticating && !isAuthenticated) {
+        showAlert("You Must Be Logged In To Access This Page", "warning");
+        navigate("/login");
+      }
 
-    if (!isAuthenticating && isAuthenticated && required !== user.roleId) {
-      showAlert("You Are Not Authorized To Access This Page", "danger");
-      goToDashboard(user.roleId);
-    }
+      if (!isAuthenticating && isAuthenticated && user.status === "not_onboarded") {
+        showAlert("Please Complete Your Onboarding", "warning");
+        navigate("/onboarding");
+      }
 
+      if (!isAuthenticating && isAuthenticated && required !== user.roleId) {
+        showAlert("You Are Not Authorized To Access This Page", "danger");
+        goToDashboard(user.roleId);
+      }
+    }
   }, [isAuthenticating, isAuthenticated, user, goToDashboard]);
 
   if (isAuthenticating || !isAuthenticated) {
     return <Spinner />;
   }
-  
+
   return <Outlet />;
 };
 

--- a/client/src/routes/CustomerRoute.jsx
+++ b/client/src/routes/CustomerRoute.jsx
@@ -15,23 +15,25 @@ const CustomerRoute = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (!isAuthenticating && !isAuthenticated) {
-      showAlert("You Must Be Logged In To Access This Page", "warning");
-      navigate("/login");
-    }
+    if (location.pathname === "/customer") {
+      if (!isAuthenticating && !isAuthenticated) {
+        showAlert("You Must Be Logged In To Access This Page", "warning");
+        navigate("/login");
+      }
 
-    if (
-      !isAuthenticating &&
-      isAuthenticated &&
-      user.status === "not_onboarded"
-    ) {
-      showAlert("Please Complete Your Onboarding", "warning");
-      navigate("/onboarding");
-    }
+      if (
+        !isAuthenticating &&
+        isAuthenticated &&
+        user.status === "not_onboarded"
+      ) {
+        showAlert("Please Complete Your Onboarding", "warning");
+        navigate("/onboarding");
+      }
 
-    if (!isAuthenticating && isAuthenticated && required !== user.roleId) {
-      showAlert("You Are Not Authorized To Access This Page", "danger");
-      goToDashboard(user.roleId);
+      if (!isAuthenticating && isAuthenticated && required !== user.roleId) {
+        showAlert("You Are Not Authorized To Access This Page", "danger");
+        goToDashboard(user.roleId);
+      }
     }
   }, [isAuthenticating, isAuthenticated, user, goToDashboard]);
 


### PR DESCRIPTION
This pull request introduces a safeguard to ensure that authentication and authorization checks are only applied when the user is on specific routes (`/admin` or `/customer`). This improves the logic in the `AdminRoute` and `CustomerRoute` components by adding an additional condition to the `useEffect` hooks.

Authentication and authorization logic improvements:

* [`client/src/routes/AdminRoute.jsx`](diffhunk://#diff-317aca4410d193813aa26aff3fc89ce8a4389ce94d543568c8921a6d1013cf7eR19-R20): Updated the `useEffect` hook to check if the current path is `/admin` before performing authentication and authorization checks. This ensures the logic is only triggered when the user is on the admin route. [[1]](diffhunk://#diff-317aca4410d193813aa26aff3fc89ce8a4389ce94d543568c8921a6d1013cf7eR19-R20) [[2]](diffhunk://#diff-317aca4410d193813aa26aff3fc89ce8a4389ce94d543568c8921a6d1013cf7eL33-R35)
* [`client/src/routes/CustomerRoute.jsx`](diffhunk://#diff-46d9e293f0b2254d409b8c6eca0968cae8199036da5b38680de718b7c11f4c7eR18): Similarly, updated the `useEffect` hook to check if the current path is `/customer` before performing authentication and authorization checks. This ensures the logic is only triggered when the user is on the customer route. [[1]](diffhunk://#diff-46d9e293f0b2254d409b8c6eca0968cae8199036da5b38680de718b7c11f4c7eR18) [[2]](diffhunk://#diff-46d9e293f0b2254d409b8c6eca0968cae8199036da5b38680de718b7c11f4c7eR37)