### PR TITLE
Fix: update route checks to use startsWith

### DIFF
--- a/client/src/routes/AdminRoute.jsx
+++ b/client/src/routes/AdminRoute.jsx
@@ -16,7 +16,7 @@ const AdminRoute = () => {
   const navigate = useNavigate();
 
     useEffect(() => {
-    if (location.pathname === "/admin") {
+    if (location.pathname.startsWith("/admin")) {
 
       if (!isAuthenticating && !isAuthenticated) {
         showAlert("You Must Be Logged In To Access This Page", "warning");

--- a/client/src/routes/CustomerRoute.jsx
+++ b/client/src/routes/CustomerRoute.jsx
@@ -15,7 +15,7 @@ const CustomerRoute = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (location.pathname === "/customer") {
+    if (location.pathname.startsWith("/customer")) {
       if (!isAuthenticating && !isAuthenticated) {
         showAlert("You Must Be Logged In To Access This Page", "warning");
         navigate("/login");

--- a/client/src/routes/PrivateRoute.jsx
+++ b/client/src/routes/PrivateRoute.jsx
@@ -20,7 +20,7 @@ function PrivateRoute({ required }) {
 
     if (!isAuthenticating && required && !required.includes(user.status)) {
       // if user didn't come from login display alert
-      if (location.pathname !== "/onboarding") {
+      if (!location.pathname.startsWith("/onboarding")) {
         showAlert("You Are Not Authorized To Access This Page", "danger");
       }
       goToDashboard(user.roleId);


### PR DESCRIPTION
This pull request fixes the bug. By updating the `location.pathname` check to `startsWith` in order to encompass the main private route and subpaths.

### Route Access Logic Updates:
* [`client/src/routes/AdminRoute.jsx`](diffhunk://#diff-317aca4410d193813aa26aff3fc89ce8a4389ce94d543568c8921a6d1013cf7eL19-R19): Updated the condition to check if the current path starts with `/admin` instead of matching it exactly. This ensures subpaths under `/admin` are also validated.
* [`client/src/routes/CustomerRoute.jsx`](diffhunk://#diff-46d9e293f0b2254d409b8c6eca0968cae8199036da5b38680de718b7c11f4c7eL18-R18): Modified the condition to check if the current path starts with `/customer` instead of matching it exactly, allowing subpaths under `/customer` to be included.
* [`client/src/routes/PrivateRoute.jsx`](diffhunk://#diff-f221ea7285466d5270a8d82587cd92393b09efeafe9c994d4ffc25336f5a1e57L23-R23): Adjusted the condition to verify if the current path starts with `/onboarding` rather than checking for an exact match, ensuring subpaths under `/onboarding` are handled correctly.