### PR TITLE
Update: include expiration time in alert dispatch

### DIFF
--- a/client/src/store/actions/alertsActions.js
+++ b/client/src/store/actions/alertsActions.js
@@ -17,7 +17,7 @@ export const showAlert = (message, type) => {
 
   const id = uuidv4();
   const expiresAt = Date.now() + duration; 
-  store.dispatch(addAlert({ id, message, type }));
+  store.dispatch(addAlert({ id, message, type, expiresAt }));
 
   const timeoutId = setTimeout(() => {
     removeAlertIfExists(id);


### PR DESCRIPTION
This pull request updates the `showAlert` function in `alertsActions.js` to include an expiration timestamp which I forgot to add.

Key change:

* [`client/src/store/actions/alertsActions.js`](diffhunk://#diff-77be7f9bb9f8be9eeef40d1872a24af70d260bc67bb981f8174d7ebdb60ea4deL20-R20): Modified the `showAlert` function to include an `expiresAt` property in the dispatched alert object. This allows alerts to have an expiration timestamp for better lifecycle management.